### PR TITLE
Update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First you need to install PyTorch. Please refer to [PyTorch installation page](h
 When PyTorch has been installed, Simple Representation can be installed using pip as follows:
 
 ```
-pip install simplerepresentation
+pip install simplerepresentations
 ```
 
 ### From source

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This library is based on the [Transformers](https://github.com/huggingface/trans
 
 ## Installation
 
-This repository is tested on Python 3.6.8 and PyTorch 1.2.0
+This repository is tested on Python 3.8.13 and PyTorch 1.7.1
 
 ### With `pip`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy=1.14.5
-torch=1.2.0
-transformers=2.3.0
-tqdm=4.36.1
+numpy>=1.22
+torch>=1.7.1
+transformers>=3.1.0
+tqdm>=4.36.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='simplerepresentations',
-    version='0.0.4',
+    version='0.0.5',
     author='Ali Fadel',
     author_email='aliosm1997@gmail.com',
     description='Easy-to-use text representations extraction library based on the Transformers library.',
@@ -13,11 +13,11 @@ setup(
     license='Apache',
     url='https://github.com/AliOsm/simplerepresentations',
     packages=find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'numpy',
         'torch',
-        'transformers',
+        'transformers>=3.1.0',
         'tqdm'
     ],
     classifiers=[

--- a/simplerepresentations/representation_model.py
+++ b/simplerepresentations/representation_model.py
@@ -110,7 +110,7 @@ class RepresentationModel:
 				inputs = self._get_inputs_dict(batch)
 
 				if self.model_type in self.MODELS_W_SENREP:
-					_, sentences_representations, tokens_representations = self.model(**inputs)
+					_, sentences_representations, tokens_representations = self.model(**inputs, return_dict=False)
 
 					sentences_representations = np.array([sentences_representation.cpu().numpy() for sentences_representation in sentences_representations])
 					all_sentences_representations.extend(sentences_representations)


### PR DESCRIPTION
I use this library in two repositories and while updating the requirements of these, I came across the same issue as described in #4.
Figured out that this is related to a change in the transformers library making the default output type of models dict instead of tuple. This is fixed by enforcing tuple as a model output.

@AliOsm Would be great if we could merge this into your repository and allow this new version to be installed directly via pip, as well. Thank you!